### PR TITLE
add ci support for ts error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 node_modules
 dist
-bin
 .env

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Webpack plugin that simplifies client/server boundaries in React Server Compon
 
 - [Installation](#user-content-installation)
 - [Example](#user-content-example)
+- [Continuous Integration](#user-content-continuous-integration)
 - [Why does this exist?](#user-content-why-does-this-exist)
 
 ## Installation
@@ -74,6 +75,20 @@ export default function Page() {
   return <Counter />;
 }
 ```
+
+## Continuous Integration
+
+Since TypeScript plugins aren't executed during `tsc` builds, you'll need to run the client attribute checks separately with `next-client-attr`. For example, add the following to your typechecking script:
+
+```json
+{
+  "scripts": {
+    "typecheck": "next-client-attr && tsc --noEmit"
+  }
+}
+```
+
+This will first validate your client attributes and then run the TypeScript compiler checks.
 
 ## Why does this exist?
 

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "next-client-attr && tsc --noEmit"
   },
   "dependencies": {
     "client-only": "^0.0.1",

--- a/lib/package.json
+++ b/lib/package.json
@@ -4,6 +4,9 @@
   "main": "./dist/index.js",
   "sideEffects": false,
   "repository": "https://github.com/jjenzz/next-client-attr-webpack-plugin",
+  "bin": {
+    "next-client-attr": "./dist/bin/check.js"
+  },
   "files": [
     "dist",
     "README.md"

--- a/lib/src/bin/check.ts
+++ b/lib/src/bin/check.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import ts from 'typescript';
+import { ClientAttrPlugin } from '../ts-plugin';
+
+function check() {
+  const configPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists, 'tsconfig.json');
+  let hasErrors = false;
+
+  if (!configPath) {
+    console.error('Could not find a valid tsconfig.json.');
+    process.exit(1);
+  }
+
+  const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+
+  if (error) {
+    console.error('Error reading tsconfig.json:', error.messageText);
+    process.exit(1);
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(config, ts.sys, process.cwd());
+  const program = ts.createProgram({
+    rootNames: parsedConfig.fileNames,
+    options: parsedConfig.options,
+  });
+
+  const checker = program.getTypeChecker();
+  const plugin = new ClientAttrPlugin(ts, checker);
+  const formatHost: ts.FormatDiagnosticsHost = {
+    getCanonicalFileName: (path) => path,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    getNewLine: () => ts.sys.newLine,
+  };
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile || sourceFile.fileName.includes('node_modules')) {
+      continue;
+    }
+
+    const diagnostics = plugin.getSemanticDiagnostics(sourceFile);
+    if (diagnostics.length > 0) {
+      console.error(ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost));
+      hasErrors = true;
+    }
+  }
+
+  if (hasErrors) process.exit(1);
+  process.exit(0);
+}
+
+check();

--- a/lib/src/ts-plugin.ts
+++ b/lib/src/ts-plugin.ts
@@ -27,9 +27,9 @@ class ClientAttrPlugin {
   #typescript: typeof ts;
   #checker: ts.TypeChecker;
 
-  constructor(typescript: typeof ts, info: ts.server.PluginCreateInfo) {
+  constructor(typescript: typeof ts, checker: ts.TypeChecker) {
     this.#typescript = typescript;
-    this.#checker = info.languageService.getProgram()?.getTypeChecker()!;
+    this.#checker = checker;
   }
 
   public getSemanticDiagnostics(sourceFile: ts.SourceFile): ts.Diagnostic[] {
@@ -206,7 +206,8 @@ function createTSPlugin({ typescript }: { typescript: typeof ts }) {
       proxy[k] = (...args: Array<any>) => (ls[k] as any).apply(ls, args);
     }
 
-    const plugin = new ClientAttrPlugin(typescript, info);
+    const checker = info.languageService.getProgram()?.getTypeChecker()!;
+    const plugin = new ClientAttrPlugin(typescript, checker);
 
     proxy.getSemanticDiagnostics = (fileName: string) => {
       const prior = ls.getSemanticDiagnostics(fileName);
@@ -224,4 +225,4 @@ function createTSPlugin({ typescript }: { typescript: typeof ts }) {
 
 /* ---------------------------------------------------------------------------------------------- */
 
-export { createTSPlugin };
+export { ClientAttrPlugin, createTSPlugin };


### PR DESCRIPTION
# Summary

since TypeScript language service plugins aren't executed during `tsc` builds, this adds a separate bin script that can be run alongside type checking to report client attribute errors during CI. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
